### PR TITLE
Update main.gd to include an RST warning

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -29,7 +29,7 @@ func run():
 		return
 
 	if frzr.get_available_disks().size() == 0:
-		var msg := "No available disks were detected. Unable to proceed with installation."
+		var msg := "No available disks were detected. Unable to proceed with installation. If you have an Intel CPU please make sure to turn off RST in BIOS settings."
 		dialog.open(msg, "OK", "Cancel")
 		await dialog.choice_selected
 		


### PR DESCRIPTION
Generally the main issue with having Intel RST enabled is that ChimeraOS won't detect your drives when booting in UEFI mode. This adds an extra sentence to the end of the no drives detected error to inform users that such a feature must be set to off to detect said drives.

This will not solve every case of RST, however, because sometimes the installation media will detect itself as an installable drive. I am still unsure of how to warn them of this in that situation, but this should be enough to inform most users who have RST enabled.