### PR TITLE
Do not list devices with a zero size

### DIFF
--- a/core/systems/frzr/frzr.gd
+++ b/core/systems/frzr/frzr.gd
@@ -35,6 +35,8 @@ func get_available_disks() -> Array[Disk]:
 		if not line.contains("disk"):
 			continue
 		var parts := line.split(" ", false, 3)
+		if parts[2] as int == 0:
+			continue
 		var disk := Disk.new()
 		disk.name = parts[0]
 		disk.path = "/dev/" + disk.name

--- a/core/systems/frzr/frzr.gd
+++ b/core/systems/frzr/frzr.gd
@@ -35,7 +35,7 @@ func get_available_disks() -> Array[Disk]:
 		if not line.contains("disk"):
 			continue
 		var parts := line.split(" ", false, 3)
-		if parts[2] as int == 0:
+		if parts[2] == "0B":
 			continue
 		var disk := Disk.new()
 		disk.name = parts[0]


### PR DESCRIPTION
This will avoid block devices with a zero size from being listed. Imagine devices such as SD card readers. 